### PR TITLE
Drawable class and Game::Sync function

### DIFF
--- a/pong-sfml/main.cpp
+++ b/pong-sfml/main.cpp
@@ -228,7 +228,10 @@ void Game::sync()
 	window->clear();
 
 	for (auto i : entities)
-		window->draw(*i);
+	{
+		if (i->Enabled && i->Visible)
+			window->draw(*i);
+	}
 	
 	window->display();
 }


### PR DESCRIPTION
Override sf::Drawable to include Visible and Enabled flags for better rendering controls and include them in the Sync frame function